### PR TITLE
Datefix

### DIFF
--- a/blocks/chart-vrapp/chart-vrapp.js
+++ b/blocks/chart-vrapp/chart-vrapp.js
@@ -154,7 +154,7 @@ export default function decorate(block) {
     (async function(){
       let res;
       if(!sessionStorage.getItem('${endpoint}')){
-        const resp = await fetch('https://lqmig3v5eb.execute-api.us-east-1.amazonaws.com/helix-services/run-query/ci5237/${endpoint}', {
+        const resp = await fetch('https://lqmig3v5eb.execute-api.us-east-1.amazonaws.com/helix-services/run-query/ci5255/${endpoint}', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/x-www-form-urlencoded'

--- a/blocks/chart-vrapp/chart-vrapp.js
+++ b/blocks/chart-vrapp/chart-vrapp.js
@@ -154,7 +154,7 @@ export default function decorate(block) {
     (async function(){
       let res;
       if(!sessionStorage.getItem('${endpoint}')){
-        const resp = await fetch('https://lqmig3v5eb.execute-api.us-east-1.amazonaws.com/helix-services/run-query/ci5189/${endpoint}', {
+        const resp = await fetch('https://lqmig3v5eb.execute-api.us-east-1.amazonaws.com/helix-services/run-query/ci5237/${endpoint}', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/x-www-form-urlencoded'
@@ -177,7 +177,7 @@ export default function decorate(block) {
         return ymd2Date(a.year, a.month, a.day) < ymd2Date(b.year, b.month, b.day)
       });
       
-      var labels = last30Days(plotData).map(row => [row.month, row.day, row.year%2000].join('/'));
+      var labels = last30Days(plotData).map(row => [row.year%2000, row.month, row.day].join('-'));
       var series = last30Days(plotData).map(row => row.${tableColumn});
 
       // Specify the configuration items and data for the chart

--- a/blocks/chart-vrapp/chart-vrapp.js
+++ b/blocks/chart-vrapp/chart-vrapp.js
@@ -177,7 +177,7 @@ export default function decorate(block) {
         return ymd2Date(a.year, a.month, a.day) < ymd2Date(b.year, b.month, b.day)
       });
       
-      var labels = last30Days(plotData).map(row => [row.year%2000, row.month, row.day].join('-'));
+      var labels = last30Days(plotData).map(row => [row.year, row.month, row.day].join('-'));
       var series = last30Days(plotData).map(row => row.${tableColumn});
 
       // Specify the configuration items and data for the chart


### PR DESCRIPTION
Changed date format from mm/dd/yy (American format) to yyyy-mm-dd which is less ambiguous.  Using a new run-query branch deploy to try to fix a date sorting issue which is showing late 2022 dates after early 2023 dates.

Test URLs:
- Before: https://main--franklin-analytics--marquiserosier.hlx.page/views/home?domainkey=...
- After: https://datefix--franklin-analytics--marquiserosier.hlx.page/views/home?domainkey=...
